### PR TITLE
Fixes

### DIFF
--- a/Passwordless-Email/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-Email/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-Email/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
+++ b/Passwordless-Email/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";

--- a/Passwordless-Email/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-Email/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-Email/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
+++ b/Passwordless-Email/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";

--- a/Passwordless-SMS/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-SMS/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-SMS/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
+++ b/Passwordless-SMS/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";

--- a/Passwordless-SMS/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-SMS/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-TouchID/CustomUI/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-TouchID/CustomUI/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-TouchID/CustomUI/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
+++ b/Passwordless-TouchID/CustomUI/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";

--- a/Passwordless-TouchID/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-TouchID/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-TouchID/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
+++ b/Passwordless-TouchID/Lock/ObjC/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";

--- a/Passwordless-TouchID/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
+++ b/Passwordless-TouchID/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.h
@@ -91,7 +91,7 @@ FOUNDATION_EXPORT NSString * const A0ScopeOpenId;
  */
 FOUNDATION_EXPORT NSString * const A0ScopeOfflineAccess;
 /**
- 'openid profile' scope
+ 'openid name email' scope
  */
 FOUNDATION_EXPORT NSString * const A0ScopeProfile;
 

--- a/Passwordless-TouchID/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
+++ b/Passwordless-TouchID/Lock/Swift/Pods/Lock/Pod/Classes/Core/A0AuthParameters.m
@@ -36,7 +36,7 @@ NSString * const A0ParameterConnection = @"connection";
 
 NSString * const A0ScopeOpenId = @"openid";
 NSString * const A0ScopeOfflineAccess = @"offline_access";
-NSString * const A0ScopeProfile = @"openid profile";
+NSString * const A0ScopeProfile = @"openid name email";
 
 NSString * const A0ParameterAPIType = @"api_type";
 NSString * const A0ParameterTarget = @"target";


### PR DESCRIPTION
All occurrences of the “openid profile” scope have been replaced with
“openid name email”.